### PR TITLE
Use typeof to check presence of process instead of truthyness

### DIFF
--- a/build/cookie.js
+++ b/build/cookie.js
@@ -24,7 +24,7 @@ var _objectAssign2 = _interopRequireDefault(_objectAssign);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var IS_NODE = typeof document === 'undefined' || process && process.env && process.env.NODE_ENV === 'test';
+var IS_NODE = typeof document === 'undefined' || typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test';
 var _rawCookie = {};
 var _res = void 0;
 

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -5,7 +5,9 @@ import objectAssign from 'object-assign'
 
 const IS_NODE =
   typeof document === 'undefined' ||
-  (process && process.env && process.env.NODE_ENV === 'test')
+  (typeof process !== 'undefined' &&
+    process.env &&
+    process.env.NODE_ENV === 'test')
 let _rawCookie = {}
 let _res
 


### PR DESCRIPTION
I recently had some issues with `react-cookies` in context of [Storybook](https://storybook.js.org/) where my component keeps crashing because of a 
```
ReferenceError: process is not defined
```
For some reason `process` in the context of my Storybook instance is not defined. While I will fix this of course, I thought I might make `react-cookies` a tad more robust by checking for the presence of `process` with `typeof`.